### PR TITLE
Small fix with args for convert_qubo func in advantage.py

### DIFF
--- a/QHyper/solvers/quantum_annealing/dwave/advantage.py
+++ b/QHyper/solvers/quantum_annealing/dwave/advantage.py
@@ -66,7 +66,7 @@ class Advantage(Solver):
         self.token = token
 
         if use_clique_embedding:
-            args = self.weigths if self.weigths else []
+            args = getattr(self, "weights", [])
             qubo = Converter.create_qubo(self.problem, args)
             qubo_terms, offset = convert_qubo_keys(qubo)
             bqm = BinaryQuadraticModel.from_qubo(qubo_terms, offset=offset)


### PR DESCRIPTION
Advantage has no weights. Quick error fix.
![obraz](https://github.com/user-attachments/assets/3f2310a9-4999-42c2-928c-4d6a8a1a27f9)
